### PR TITLE
Update source to include callable-flows tutorial

### DIFF
--- a/src/tutorialManager/en/repo_metadata.json
+++ b/src/tutorialManager/en/repo_metadata.json
@@ -465,6 +465,46 @@
 					],
 			    		"deployedResources" : [
 					]
+				},
+				{
+		        	"name"          : "Callable Flows",
+		            	"version"	: "0.1",
+		            	"iibVersions"	: "10.*-11.*",
+		            	"shortDesc"     : "Learn how to split flow processing using CallableFlow nodes on IBM Integration Bus Version 10.0.0.4",
+		            	"detailsURL"    : "http://ajpaton.github.io/callable-flows-tutorial/en/details.html",
+		            	"stepsURL"      : "http://ajpaton.github.io/callable-flows-tutorial/en/steps.html",
+				"zipURL" 	: "https://github.com/ajpaton/callable-flows-tutorial/releases/download/V1/BTM_RETAIL.zip",
+					"barFile" : "<workspace>/CallableFlowBARFiles/callable_flows.bar",
+					"visible"	: "true",
+					"tags"	: "",
+					"isPattern"	: "false",
+					"isFavorite"	: "true",
+					"projects"	: "CallableFlowBARFiles:CallableTimestamp:CallableTimestampAlternate:HTTPParentApplication:TestCallableFlows",
+					"editorResPaths": [
+						{
+							"id" : "TimestampMyJSON",
+							"editor" : "",
+							"wspath" : "<workspace>/HTTPParentApplication/TimestampMyJSON.msgflow"
+						}
+					],
+			    		"deployedResources" : [
+							{
+							"type": "application",
+							"path": "HTTPParentApplication"
+							},
+							{
+							"type": "application",
+							"path": "CallableTimestamp"
+							},
+							{
+							"type": "application",
+							"path": "CallableTimestampAlternate"
+							},
+							{
+							"type": "application",
+							"path": "TestCallableFlows"
+							},
+					]
 				}
 			]
 		}, 

--- a/src/tutorialManager/en/repo_metadata.json
+++ b/src/tutorialManager/en/repo_metadata.json
@@ -266,6 +266,42 @@
 						]
 				},
 				{
+		        	"name"          : "Callable Flows",
+		            	"version"	: "1.0",
+		            	"iibVersions"	: "10.*-11.*",
+		            	"shortDesc"     : "Learn how to split flow processing using CallableFlow nodes",
+		            	"detailsURL"    : "http://ot4i.github.io/callable-flows-tutorial/en/details.html",
+		            	"stepsURL"      : "http://ot4i.github.io/callable-flows-tutorial/en/steps.html",
+				"zipURL" 	: "https://github.com/ot4i/callable-flows-tutorial/releases/download/v1.0/CallableFlowsPI.zip",
+					"barFile" : "<workspace>/CallableFlowBARFiles/callable_flows.bar",
+					"visible"	: "true",
+					"tags"	: "callableflows;map",
+					"isPattern"	: "false",
+					"isFavorite"	: "true",
+					"projects"	: "CallableFlowBARFiles:CallableTimestamp:CallableTimestampAlternate:CallingParentApplication",
+					"editorResPaths": [
+						{
+							"id" : "TimestampMyJSON",
+							"editor" : "flow",
+							"wspath" : "<workspace>/CallingParentApplication/TimestampMyJSON.msgflow"
+						}
+					],
+			    		"deployedResources" : [
+							{
+							"type": "application",
+							"path": "CallingParentApplication"
+							},
+							{
+							"type": "application",
+							"path": "CallableTimestamp"
+							},
+							{
+							"type": "application",
+							"path": "CallableTimestampAlternate"
+							}
+					]
+				},
+				{
         				"name": "Subscribing to receive MQTT events",
         				"version": "1.0",
         				"iibVersions": "10.*-11.*",
@@ -464,46 +500,6 @@
 						}
 					],
 			    		"deployedResources" : [
-					]
-				},
-				{
-		        	"name"          : "Callable Flows",
-		            	"version"	: "0.1",
-		            	"iibVersions"	: "10.*-11.*",
-		            	"shortDesc"     : "Learn how to split flow processing using CallableFlow nodes on IBM Integration Bus Version 10.0.0.4",
-		            	"detailsURL"    : "http://ajpaton.github.io/callable-flows-tutorial/en/details.html",
-		            	"stepsURL"      : "http://ajpaton.github.io/callable-flows-tutorial/en/steps.html",
-				"zipURL" 	: "https://github.com/ajpaton/callable-flows-tutorial/releases/download/V1/BTM_RETAIL.zip",
-					"barFile" : "<workspace>/CallableFlowBARFiles/callable_flows.bar",
-					"visible"	: "true",
-					"tags"	: "",
-					"isPattern"	: "false",
-					"isFavorite"	: "true",
-					"projects"	: "CallableFlowBARFiles:CallableTimestamp:CallableTimestampAlternate:HTTPParentApplication:TestCallableFlows",
-					"editorResPaths": [
-						{
-							"id" : "TimestampMyJSON",
-							"editor" : "",
-							"wspath" : "<workspace>/HTTPParentApplication/TimestampMyJSON.msgflow"
-						}
-					],
-			    		"deployedResources" : [
-							{
-							"type": "application",
-							"path": "HTTPParentApplication"
-							},
-							{
-							"type": "application",
-							"path": "CallableTimestamp"
-							},
-							{
-							"type": "application",
-							"path": "CallableTimestampAlternate"
-							},
-							{
-							"type": "application",
-							"path": "TestCallableFlows"
-							},
 					]
 				}
 			]


### PR DESCRIPTION
Don't think this souree is _actually_ what is used by the Toolkit but want to keep it in sync with what's in gh-pages branch.
